### PR TITLE
Set packages.default for `nix run`

### DIFF
--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -23,7 +23,7 @@
         # system.
 
         # Equivalent to  inputs'.nixpkgs.legacyPackages.hello;
-        packages.hello = pkgs.hello;
+        packages.default = pkgs.hello;
       };
       flake = {
         # The usual flake attributes can be defined here, including system-


### PR DESCRIPTION
With the pre-2.7 `defaultPackage` key, one would write
```
defaultPackage = packages.hello
```

I guess you can do the same in 2.7, but then you have two attrs in packages, which seems like it might confuse tooling:

```
packages.default = packages.hello
```

I wonder if packages.default shouldn't be a string? but then it would need validation...