### PR TITLE
Skip getExe when `app.<name>.program` is a string

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -12,7 +12,11 @@ let
     mkPerSystemOption
     ;
 
-  programType = lib.types.coercedTo lib.types.package getExe lib.types.str;
+  programType = lib.types.coercedTo derivationType getExe lib.types.str;
+
+  derivationType = lib.types.package // {
+    check = lib.isDerivation;
+  };
 
   getExe = x:
     "${lib.getBin x}/bin/${x.meta.mainProgram or (throw ''Package ${x.name or ""} does not have meta.mainProgram set, so I don't know how to find the main executable. You can set meta.mainProgram, or pass the full path to executable, e.g. program = "''${pkg}/bin/foo"'')}";


### PR DESCRIPTION
Fixes #42 