### PR TITLE
Add `moduleWithSystem` flake module parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,24 @@ See [flake.parts](https://flake.parts/options.html)
 
  -  `getSystem`: function from system string to the `config` of the appropriate `perSystem`.
 
+ -  `moduleWithSystem`: function that brings the `perSystem` module arguments.
+    This allows a module to reference the defining flake without introducing
+    global variables (which may conflict).
+
+    ```nix
+    { moduleWithSystem, ... }:
+    {
+      nixosModules.default = moduleWithSystem (
+        perSystem@{ config }:  # NOTE: only explicit params will be in perSystem
+        nixos@{ ... }:
+        {
+          services.foo.package = perSystem.config.packages.foo;
+          imports = [ ./nixos-foo.nix ];
+        }
+      );
+    }
+    ```
+
  -  `withSystem`: enter the scope of a system. Worked example:
 
     ```nix

--- a/all-modules.nix
+++ b/all-modules.nix
@@ -7,6 +7,7 @@
     ./modules/devShells.nix
     ./modules/flake.nix
     ./modules/legacyPackages.nix
+    ./modules/moduleWithSystem.nix
     ./modules/nixosConfigurations.nix
     ./modules/nixosModules.nix
     ./modules/nixpkgs.nix

--- a/modules/moduleWithSystem.nix
+++ b/modules/moduleWithSystem.nix
@@ -1,0 +1,32 @@
+{ config, lib, withSystem, ... }:
+{
+  config = {
+    _module.args = {
+      moduleWithSystem =
+        module:
+
+        { config, ... }:
+        let
+          system =
+            config._module.args.system or
+              config._module.args.pkgs.stdenv.hostPlatform.system or
+                (throw "moduleWithSystem: Could not determine the configuration's system parameter for this module system application.");
+
+          allArgs = withSystem system (args: args);
+
+          lazyArgsPerParameter = f: builtins.mapAttrs
+            (k: v: allArgs.${k} or (throw "moduleWithSystem: module argument `${k}` does not exist."))
+            (builtins.functionArgs f);
+
+          # Use reflection to make the call lazy in the argument.
+          # Restricts args to the ones declared.
+          callLazily = f: a: f (lazyArgsPerParameter f);
+        in
+        {
+          imports = [
+            (callLazily module allArgs)
+          ];
+        };
+    };
+  };
+}


### PR DESCRIPTION
`withSystem` is too strict to be usable inside the module fixed point.

This uses the same trick that makes `specialArgs` work in order to add the correct `perSystem` to the lexical scope.

The alternative of just adding a lazy withSystem would require the call to be performed inside the module body, which feels messier because it makes for a more "interleaved" lexical scope, if that makes sense. The current solution puts the outer scope in the outer function.