### PR TITLE
legacyPackages: anything -> raw

### DIFF
--- a/modules/legacyPackages.nix
+++ b/modules/legacyPackages.nix
@@ -16,10 +16,10 @@ in
   options = {
     flake = mkSubmoduleOptions {
       legacyPackages = mkOption {
-        type = types.lazyAttrsOf (types.lazyAttrsOf types.anything);
+        type = types.lazyAttrsOf (types.lazyAttrsOf types.raw);
         default = { };
         description = ''
-          Per system, an attribute set of anything. This is also used by <literal>nix build .#&lt;attrpath></literal>.
+          Per system, an attribute set of unmergeable values. This is also used by <literal>nix build .#&lt;attrpath></literal>.
         '';
       };
     };
@@ -27,10 +27,10 @@ in
     perSystem = mkPerSystemOption ({ config, ... }: {
       options = {
         legacyPackages = mkOption {
-          type = types.lazyAttrsOf types.anything;
+          type = types.lazyAttrsOf types.raw;
           default = { };
           description = ''
-            An attribute set of anything. This is also used by <literal>nix build .#&lt;attrpath></literal>.
+            An attribute set of unmergeable values. This is also used by <literal>nix build .#&lt;attrpath></literal>.
           '';
         };
       };


### PR DESCRIPTION
The `anything` type is too strict, because it uses `attrsOf`
internally, filtering out `mkIf` attrs and therefore evaluating
attribute values when only the names would be needed.

Furthermore, it is not safe to make assumptions about the objects
in legacyPackages, because while most attributes contain packages
or package sets, anything is allowed, so we don't know for sure how
to merge.

Fixes #52