### PR TITLE
add formatter schema

### DIFF
--- a/all-modules.nix
+++ b/all-modules.nix
@@ -6,6 +6,7 @@
     ./modules/darwinModules.nix
     ./modules/devShells.nix
     ./modules/flake.nix
+    ./modules/formatter.nix
     ./modules/legacyPackages.nix
     ./modules/moduleWithSystem.nix
     ./modules/nixosConfigurations.nix

--- a/modules/formatter.nix
+++ b/modules/formatter.nix
@@ -28,7 +28,7 @@ in
       _file = ./formatter.nix;
       options = {
         packages = mkOption {
-          type = types.package;
+          type = types.nullOr types.package;
           default = null;
           description = ''
             A package used by <literal>nix fmt</literal>.

--- a/modules/formatter.nix
+++ b/modules/formatter.nix
@@ -1,0 +1,55 @@
+{ config, lib, flake-parts-lib, ... }:
+let
+  inherit (lib)
+    filterAttrs
+    mapAttrs
+    mkOption
+    optionalAttrs
+    types
+    ;
+  inherit (flake-parts-lib)
+    mkSubmoduleOptions
+    mkPerSystemOption
+    ;
+in
+{
+  options = {
+    flake = mkSubmoduleOptions {
+      formatter = mkOption {
+        type = types.lazyAttrsOf types.package;
+        default = { };
+        description = ''
+          Per system package used by <literal>nix fmt</literal>.
+        '';
+      };
+    };
+
+    perSystem = mkPerSystemOption ({ config, ... }: {
+      _file = ./formatter.nix;
+      options = {
+        packages = mkOption {
+          type = types.package;
+          default = null;
+          description = ''
+            A package used by <literal>nix fmt</literal>.
+          '';
+        };
+      };
+    });
+  };
+  config = {
+    flake.formatter =
+      mapAttrs
+        (k: v: v.formatter)
+        (filterAttrs
+          (k: v: v.formatter != null)
+          config.allSystems
+        );
+
+    perInput = system: flake:
+      optionalAttrs (flake?formatter.${system}) {
+        formatter = flake.formatter.${system};
+      };
+
+  };
+}

--- a/modules/formatter.nix
+++ b/modules/formatter.nix
@@ -27,7 +27,7 @@ in
     perSystem = mkPerSystemOption ({ config, ... }: {
       _file = ./formatter.nix;
       options = {
-        packages = mkOption {
+        formatter = mkOption {
           type = types.nullOr types.package;
           default = null;
           description = ''


### PR DESCRIPTION
This is needed for flakes that want to support `nix fmt`.

Right now it's missing some testing as I didn't find a test framework for it.

Needed by https://github.com/numtide/treefmt/pull/169
