### PR TITLE
Filter away unset output attributes

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -1,11 +1,13 @@
 { lib }:
 let
   inherit (lib)
-    mkOption
-    mkOptionType
     defaultFunctor
+    filterAttrs
     isAttrs
     isFunction
+    mkIf
+    mkOption
+    mkOptionType
     showOption
     types
     ;
@@ -74,7 +76,8 @@ let
       };
 
     mkFlake = args: module:
-      (flake-parts-lib.evalFlakeModule args module).config.flake;
+      # filter away top-level nulls
+      filterAttrs (k: v: v != null) (flake-parts-lib.evalFlakeModule args module).config.flake;
 
     # For extending options in an already declared submodule.
     # Workaround for https://github.com/NixOS/nixpkgs/issues/146882
@@ -98,6 +101,7 @@ let
         type = flake-parts-lib.mkPerSystemType module;
       };
 
+    mkIfNonEmptySet = set: mkIf (set != {}) set;
   };
 
 in

--- a/modules/darwinModules.nix
+++ b/modules/darwinModules.nix
@@ -15,9 +15,11 @@ in
   options = {
     flake = mkSubmoduleOptions {
       darwinModules = mkOption {
-        type = types.lazyAttrsOf types.unspecified;
-        default = { };
-        apply = mapAttrs (k: v: { _file = "${toString self.outPath}/flake.nix#darwinModules.${k}"; imports = [ v ]; });
+        type = types.nullOr (types.lazyAttrsOf types.unspecified);
+        default = null;
+        apply = x: if x == null
+          then null
+          else mapAttrs (k: v: { _file = "${toString self.outPath}/flake.nix#darwinModules.${k}"; imports = [ v ]; }) x;
         description = ''
           Nix-darwin modules.
         '';

--- a/modules/nixosConfigurations.nix
+++ b/modules/nixosConfigurations.nix
@@ -13,8 +13,8 @@ in
   options = {
     flake = mkSubmoduleOptions {
       nixosConfigurations = mkOption {
-        type = types.lazyAttrsOf types.raw;
-        default = { };
+        type = types.nullOr (types.lazyAttrsOf types.raw);
+        default = null;
         description = ''
           Instantiated NixOS configurations.
         '';

--- a/modules/nixosModules.nix
+++ b/modules/nixosModules.nix
@@ -15,9 +15,11 @@ in
   options = {
     flake = mkSubmoduleOptions {
       nixosModules = mkOption {
-        type = types.lazyAttrsOf types.unspecified;
-        default = { };
-        apply = mapAttrs (k: v: { _file = "${toString self.outPath}/flake.nix#nixosModules.${k}"; imports = [ v ]; });
+        type = types.nullOr (types.lazyAttrsOf types.unspecified);
+        default = null;
+        apply = x: if x == null
+          then null
+          else mapAttrs (k: v: { _file = "${toString self.outPath}/flake.nix#nixosModules.${k}"; imports = [ v ]; }) x;
         description = ''
           NixOS modules.
         '';

--- a/modules/overlays.nix
+++ b/modules/overlays.nix
@@ -14,10 +14,12 @@ in
       overlays = mkOption {
         # uniq -> ordered: https://github.com/NixOS/nixpkgs/issues/147052
         # also update description when done
-        type = types.lazyAttrsOf (types.uniq (types.functionTo (types.functionTo (types.lazyAttrsOf types.unspecified))));
+        type = types.nullOr (types.lazyAttrsOf (types.uniq (types.functionTo (types.functionTo (types.lazyAttrsOf types.unspecified)))));
         # This eta expansion exists for the sole purpose of making nix flake check happy.
-        apply = lib.mapAttrs (k: f: final: prev: f final prev);
-        default = { };
+        apply = x: if x == null
+          then null
+          else lib.mapAttrs (k: f: final: prev: f final prev) x;
+        default = null;
         example = lib.literalExpression or lib.literalExample ''
           {
             default = final: prev: {};

--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -1,8 +1,12 @@
 { config, lib, flake-parts-lib, self, ... }:
 let
   inherit (lib)
+    foldl'
     genAttrs
+    isAttrs
     mapAttrs
+    map
+    attrNames
     mkOption
     types
     ;
@@ -35,17 +39,41 @@ in
         };
       });
       apply = modules: system:
-        (lib.evalModules {
-          inherit modules;
-          prefix = [ "perSystem" system ];
-          specialArgs = {
-            inherit system;
-          };
-        }).config;
+        let
+          inherit (lib.evalModules {
+            inherit modules;
+            prefix = [ "perSystem" system ];
+            specialArgs = {
+              inherit system;
+            };
+          }) options;
+        # Almost like `config`, except undefined options are filtered away.
+        # This definition is incomplete, but is good enough for our purposes.
+        # Limitations:
+        # - Doesn't handle undefined options in submodules.
+        # - Doesn't handle undefined options that have a prefix, e.g. `_module.args`.
+        # TODO: Upstream a good version of this to Nixpkgs, probably as an extra result
+        # from `evalModules`, e.g. `result.configFiltered`.
+        #
+        # The reason we do this is that we don't want to evaluate the definitions,
+        # and only check whether they're defined. Hence we can't check for nullness,
+        # because that will evaluate a lot of stuff unnecessarily and cause errors
+        # with IFD. A more proper fix would perhaps be fixing the Nix evaluator to
+        # short circuit more, specifically, in an expression like `null != { ${x} = ...; }`,
+        # `x` should not be validated, since it's a set regardless.
+        #
+        # In general though, Nix's evaluator sucks.
+        in
+          foldl' (acc: k: acc // (
+            let v = options.${k}; in
+            if isAttrs v && v ? isDefined && v.isDefined
+              then { ${k} = v.value; }
+              else {}
+          )) {} (attrNames options);
     };
 
     allSystems = mkOption {
-      type = types.lazyAttrsOf types.unspecified;
+      type = types.unspecified;
       description = "The system-specific config for each of systems.";
       internal = true;
     };


### PR DESCRIPTION
…hello`)

This in addition also strips away unset attributes set using `flake`.

The core issue with IFD in this context, is that we want to strip away unused attributes. AFAICT, flake-parts did this in a buggy way before. Removing this entirely while fixing support for IFD was easier, but to keep support for filtering away unset attributes, a bit more complexity was needed.

The issue is that we can't use `null` as a special value to mean "unset". The reason is that while filtering over `allSystems.${system}`, checking whether `packages` has been set, doing `null == packages` will cause `packages`, an attribute set, to be evaluated to WHNF. WHNF for an attribute set entails evaluating the _keys_, and if the keys are generated using IFD, then this will fail, even if we know that no matter what the key is, this check will return false.

If the Nix evaluator is ever fixed, this feature can be somewhat cleaned up by using null checks rather than checking `isDefined`.

To make use of this feature, you can not simply do
```nix
packages = import drv;
```

You must do
```nix
packages = mkOverride 100 (mkOrder 1000 (import drv));
```

The reason is that the module system internally will try to check `._type`, but this of course will cause all of the other keys to also be evaluated.

This would also be unnecessary if the Nix evaluator were fixed.

Closes #57 