### PR TITLE
Only depend on nixpkgs/lib.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Otherwise, add the input,
 
 ```
     flake-parts.url = "github:hercules-ci/flake-parts";
-    flake-parts.inputs.nixpkgs.follows = "nixpkgs";
 ```
 
 then slide `mkFlake` between your outputs function head and body,

--- a/flake.lock
+++ b/flake.lock
@@ -1,15 +1,17 @@
 {
   "nodes": {
-    "nixpkgs": {
+    "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1653581809,
-        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
+        "dir": "lib",
+        "lastModified": 1665349835,
+        "narHash": "sha256-UK4urM3iN80UXQ7EaOappDzcisYIuEURFRoGQ/yPkug=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
+        "rev": "34c5293a71ffdb2fe054eb5288adc1882c1eb0b1",
         "type": "github"
       },
       "original": {
+        "dir": "lib",
         "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
@@ -18,7 +20,7 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs-lib": "nixpkgs-lib"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,11 +2,11 @@
   description = "Flake basics described using the module system";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-lib.url = "github:NixOS/nixpkgs/nixos-unstable?dir=lib";
   };
 
-  outputs = { self, nixpkgs, ... }: {
-    lib = import ./lib.nix { inherit (nixpkgs) lib; };
+  outputs = { self, nixpkgs-lib, ... }: {
+    lib = import ./lib.nix { inherit (nixpkgs-lib) lib; };
     templates = {
       default = {
         path = ./template/default;

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -2,7 +2,6 @@
   description = "Description for the project";
 
   inputs = {
-    flake-parts.inputs.nixpkgs.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 

--- a/template/multi-module/flake.nix
+++ b/template/multi-module/flake.nix
@@ -2,7 +2,6 @@
   description = "Description for the project";
 
   inputs = {
-    flake-parts.inputs.nixpkgs.follows = "nixpkgs";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 


### PR DESCRIPTION
This reflects the actual requirements of the core flake-parts functionality and removes any possible confusion about where lib comes from (always flake-parts's input) vs where pkgs comes from (always the flake's nixpkgs input). Flakes which use flake-parts should only ever have to override its input in the very unlikely event of a bug in lib.

Hopefully lib will be separated into its own flake some day, which will also make this a much smaller footprint.