### PR TITLE
Fix infinite recursion in inputs imports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,22 @@
 
+# 2022-12-17
+
+ - The old syntax `mkFlake { inherit self; }` is now strongly discouraged in
+ favor of:
+
+   ```nix
+   outputs = inputs@{ flake-parts, ... }:
+     flake-parts.lib.mkFlake { inherit inputs; } { /* module */ }
+   ```
+
+   This fixes an infinite recursion that occurs with the old syntax when
+   using the `inputs` module argument in `imports`.
+
+   If you're under the impression that this already worked, that's probably
+   because you were using `inputs` from the lexical scope (ie directly from
+   the flake outputs function arguments), rather than in a separate module file.
+
+
 # 2022-12-07
 
  - The `darwinModules` option has been removed. This was added in the early days

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ Otherwise, add the input,
 then slide `mkFlake` between your outputs function head and body,
 
 ```
-  outputs = { self, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit self; } {
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       flake = {
         # Put your original flake attributes here.
       };

--- a/dev/default.nix
+++ b/dev/default.nix
@@ -1,13 +1,16 @@
 let
   flake = builtins.getFlake (toString ./.);
   fmc-lib = (builtins.getFlake (toString ../.)).lib;
+  args = {
+    inherit self;
+  } // flake.inputs;
   self = {
     inherit (flake) inputs;
     outPath = ../.; # used by pre-commit module, etc
     outputs = self.config.flake;
   } //
-  fmc-lib.evalFlakeModule
-    { inherit self; }
+  fmc-lib.mkFlake
+    { inputs = args; }
     ./flake-module.nix;
 in
 self.config.flake // { inherit (flake) inputs; }

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -5,8 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit self; } {
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         # To import a flake module
         # 1. Add foo to inputs

--- a/template/multi-module/flake.nix
+++ b/template/multi-module/flake.nix
@@ -5,8 +5,8 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit self; } {
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
       imports = [
         ./hello/flake-module.nix
       ];


### PR DESCRIPTION
- The old syntax `mkFlake { inherit self; }` is now strongly discouraged in
 favor of:

   ```nix
   outputs = inputs@{ flake-parts, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } { /* module */ }
   ```

   This fixes an infinite recursion that occurs with the old syntax when
   using the `inputs` module argument in `imports`.

   If you're under the impression that this already worked, that's probably
   because you were using `inputs` from the lexical scope (ie directly from
   the flake outputs function arguments), rather than in a separate module file.