### PR TITLE
Shrink inputs footprint further

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,19 +2,16 @@
   "nodes": {
     "nixpkgs-lib": {
       "locked": {
-        "dir": "lib",
-        "lastModified": 1671359686,
-        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
+        "lastModified": 1671324337,
+        "narHash": "sha256-OZVfw69LQi2RckjPdooYrhw1I2vd28QdzEGJwI3w+jk=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "b4dd796b65c0bee6185fd2b5c84c2a207231e28f",
         "type": "github"
       },
       "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake basics described using the module system";
 
   inputs = {
-    nixpkgs-lib.url = "github:NixOS/nixpkgs/nixos-unstable?dir=lib";
+    nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
   };
 
   outputs = { self, nixpkgs-lib, ... }: {


### PR DESCRIPTION
https://github.com/hercules-ci/flake-parts/commit/13dddfdc6701f05513fa77928ee90ad628b607c5
reads:

> Hopefully lib will be separated into its own flake some day, which
> will also make this a much smaller footprint.

Here it is.

/cc @shlevy 