### PR TITLE
mkFlake: Set default module location

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -113,7 +113,15 @@ let
         );
 
     mkFlake = args: module:
-      (flake-parts-lib.evalFlakeModule args module).config.flake;
+      let
+        loc =
+          if args?inputs.self.outPath
+          then args.inputs.self.outPath + "/flake.nix"
+          else "<mkFlake argument>";
+        mod = lib.setDefaultModuleLocation loc module;
+        eval = flake-parts-lib.evalFlakeModule args mod;
+      in
+      eval.config.flake;
 
     # For extending options in an already declared submodule.
     # Workaround for https://github.com/NixOS/nixpkgs/issues/146882


### PR DESCRIPTION
Improve error messages and [debug](https://flake.parts/options/flake-parts.html#opt-debug) output.

`outPath + "/flake.nix"` is technically an unfounded assumption, except almost all calls will be made from flake.nix. It surely is a lot better than `<unknown location>`.