### PR TITLE
`easyOverlay`: support simplistic fake pkgs

### DIFF
--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -17,13 +17,13 @@ rec {
   };
 
   empty = mkFlake
-    { self = { }; }
+    { inputs.self = { }; }
     {
       systems = [ ];
     };
 
   example1 = mkFlake
-    { self = { }; }
+    { inputs.self = { }; }
     {
       systems = [ "a" "b" ];
       perSystem = { system, ... }: {
@@ -32,7 +32,7 @@ rec {
     };
 
   easyOverlay = mkFlake
-    { self = { }; }
+    { inputs.self = { }; }
     {
       imports = [ flake-parts.flakeModules.easyOverlay ];
       systems = [ "a" ];

--- a/extras/easyOverlay.nix
+++ b/extras/easyOverlay.nix
@@ -44,7 +44,12 @@ in
   config = {
     flake.overlays.default = final: prev:
       let
-        system = prev.stdenv.hostPlatform.system;
+        system =
+          prev.stdenv.hostPlatform.system or (
+            prev.system or (
+              throw "Could not determine the `hostPlatform` of Nixpkgs. Was this overlay loaded as a Nixpkgs overlay, or was it loaded into something else?"
+            )
+          );
         perSys = (getSystem system).extendModules {
           modules = [
             {


### PR DESCRIPTION
Discovered in https://github.com/hercules-ci/arion/issues/180