### PR TITLE
add lib argument to multi-module template

### DIFF
--- a/template/multi-module/hello/flake-module.nix
+++ b/template/multi-module/hello/flake-module.nix
@@ -1,6 +1,6 @@
 # Definitions can be imported from a separate file like this one
 
-{ self, ... }: {
+{ self, lib, ... }: {
   perSystem = { config, self', inputs', pkgs, ... }: {
     # Definitions like this are entirely equivalent to the ones
     # you may have directly in flake.nix.


### PR DESCRIPTION
Might be biased by my use cases but I nearly always need lib. Even if not it doesn't hurt to have it.
Also the top-level flake.nix could really use a `lib` attribute. But not sure what would be the best way to bring it in scope.
Many users will need lib, so I think it would be good to propose a sane default of how to bring it in.