### PR TITLE
[RFC] set default for systems and use a better interface for exposing packages

### DIFF
--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -66,6 +66,7 @@ in
         In other words, all valid values for `system` in e.g. `packages.<system>.foo`.
       '';
       type = types.listOf types.str;
+      default = lib.systems.flakeExposed;
     };
 
     perInput = mkOption {


### PR DESCRIPTION
Most folks I have spoken too agree that having the user specifying systems is not great ux.
It does not seem that the nix core developer are focused on fixing it any time soon.

So how about the following approach. Nixpkgs already has a great interface for a package to communicate what platforms in can be build on called `meta.platforms`. So why not having meta checks on attributes to filter out packages that are not supported in flake-parts? flake-parts already has enough of knowledge of the flake schema do this filtering. 