### PR TITLE
feat: don't output empty systems

### DIFF
--- a/modules/transposition.nix
+++ b/modules/transposition.nix
@@ -7,10 +7,9 @@ let
     mkOption
     types
     ;
-  inherit (flake-parts-lib)
-    mkSubmoduleOptions
-    mkPerSystemOption
-    ;
+
+  removeEmptySystems = attrName:
+    lib.filterAttrs (system: v: v.${attrName} != {});
 
   transpositionModule = {
     options = {
@@ -57,7 +56,7 @@ in
         (attrName: attrConfig:
           mapAttrs
             (system: v: v.${attrName})
-            config.allSystems
+            (removeEmptySystems attrName config.allSystems)
         )
         config.transposition;
 


### PR DESCRIPTION
`nix flake show` after this change:
```
├───apps
├───checks
├───devShells
├───formatter
├───legacyPackages
├───nixosConfigurations
├───nixosModules
├───overlays
└───packages
```

`nix flake show` before this change:
```
├───apps
│   ├───aarch64-darwin
│   └───x86_64-linux
├───checks
│   ├───aarch64-darwin
│   └───x86_64-linux
├───devShells
│   ├───aarch64-darwin
│   └───x86_64-linux
├───formatter
├───legacyPackages
│   ├───aarch64-darwin omitted (use '--legacy' to show)
│   └───x86_64-linux omitted (use '--legacy' to show)
├───nixosConfigurations
├───nixosModules
├───overlays
└───packages
    ├───aarch64-darwin
    └───x86_64-linux
```