### PR TITLE
Added `outPath` attribute to `self'` and `flakeModules` to `inputs'`

### DIFF
--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -93,7 +93,7 @@ in
         _file = ./perSystem.nix;
         config = {
           _module.args.inputs' = mapAttrs (k: rootConfig.perInput system) self.inputs;
-          _module.args.self' = rootConfig.perInput system self;
+          _module.args.self' = rootConfig.perInput system self // { inherit (self) outPath; };
 
           # Custom error messages
           _module.args.self = throwAliasError' "self";


### PR DESCRIPTION
Very straightforward. Was needed for [clojix](https://github.com/sajban/clojix/blob/daf44b5196071730bca5804578c177f2b4dc218a/nix/projectSubmodule.nix#L203).