### PR TITLE
support externally extensible systems

### DIFF
--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -59,14 +59,21 @@ let
 in
 {
   options = {
-    systems = mkOption {
+    systems = mkOption ({
       description = ''
         All the system types to enumerate in the flake output subattributes.
 
         In other words, all valid values for `system` in e.g. `packages.<system>.foo`.
+
+        If the `systems` flake input exists, it will be imported as the
+        default. See <https://github.com/nix-systems/nix-systems> for a
+        description of the pattern.
       '';
       type = types.listOf types.str;
-    };
+    } // (lib.optionalAttrs self.inputs?systems) {
+      # Load the systems input by default if it has been declared.
+      default = import self.inputs.systems;
+    });
 
     perInput = mkOption {
       description = ''

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -3,6 +3,8 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    # The list of systems to use
+    systems.url = "github:nix-systems/default";
   };
 
   outputs = inputs@{ flake-parts, ... }:
@@ -14,7 +16,6 @@
         # 3. Add here: foo.flakeModule
 
       ];
-      systems = [ "x86_64-linux" "aarch64-darwin" ];
       perSystem = { config, self', inputs', pkgs, system, ... }: {
         # Per-system attributes can be defined here. The self' and inputs'
         # module parameters provide easy access to attributes of the same


### PR DESCRIPTION
With this change, it becomes possible to modify the list of systems that
a flake is using, using only the flake override mechanisms.

See <https://github.com/numtide/treefmt/pull/228> and
<https://github.com/nix-systems/nix-systems>.
