### PR TITLE
perSystem: include outPath in flake attributes

### DIFF
--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -130,6 +130,11 @@ in
     # where we run in the context of an overlay, and the performance cost of the
     # extra `pkgs` makes the cost of running `perSystem` probably negligible.
     _module.args.getSystemIgnoreWarning = system: config.allSystems.${system} or (config.perSystem system);
+
+    perInput = system: flake: {
+      # Allow for input coercion to string, ex: "${inputs'.flake-parts}/shell.nix"
+      inherit (flake) outPath;
+    };
   };
 
 }


### PR DESCRIPTION
I want to pass `self'` to my nixos modules and be able to do `"${self'}/...` to refer to paths within the flake. I think it would be good for flake-parts to preserve `outPath` within `self'` and inputs in `inputs'`, so that way `self'` and `inputs'` are identical to `self` and `inputs` but with system picked out.