### PR TITLE
Add class: imports "type checking"

### DIFF
--- a/extras/flakeModules.nix
+++ b/extras/flakeModules.nix
@@ -16,6 +16,7 @@ let
       _file = "${toString moduleLocation}#flakeModules.${k}";
       key = "${toString moduleLocation}#flakeModules.${k}";
       imports = [ v ];
+      _class = "flake";
     });
     description = ''
       flake-parts modules for use by other flakes.

--- a/lib.nix
+++ b/lib.nix
@@ -120,6 +120,7 @@ let
             inputs = args.inputs or /* legacy, warned above */ self.inputs;
           } // specialArgs;
           modules = [ ./all-modules.nix (lib.setDefaultModuleLocation errorLocation module) ];
+          class = "flake";
         }
         );
 

--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -126,6 +126,7 @@ in
           specialArgs = {
             inherit system;
           };
+          class = "perSystem";
         }).config;
     };
 


### PR DESCRIPTION
Might delay a merge as it could lead to something like "unknown option _class" when loading modules from flakes with a (very) recent lib into flakes with an older lib.
Make a tag first?