### PR TITLE
Add dogfood template (fix #104 and #121)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,12 @@
           A minimal flake using flake-parts importing nixpkgs with the unfree option.
         '';
       };
+      dogfood = {
+        path = ./template/dogfood;
+        description = ''
+          A minimal flake using flake-parts creating flake modules to build its own outputs.
+        '';
+      };
     };
     flakeModules = {
       easyOverlay = ./extras/easyOverlay.nix;

--- a/template/dogfood/flake.nix
+++ b/template/dogfood/flake.nix
@@ -1,0 +1,17 @@
+{
+  description = "Description for the project";
+
+  inputs = {
+    nixpkgs_22_11.url = "github:NixOS/nixpkgs/nixos-22.11";
+  };
+
+  outputs = { flake-parts, ... }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      flake-parts.lib.mkFlake
+        {
+          # Workaround for https://github.com/hercules-ci/flake-parts/issues/148
+          inputs = inputs // { self.outPath = ./.; };
+        }
+        ./modules/dogfood.nix
+    ).flakeModules.dogfood;
+}

--- a/template/dogfood/flake.nix
+++ b/template/dogfood/flake.nix
@@ -5,12 +5,17 @@
     nixpkgs_22_11.url = "github:NixOS/nixpkgs/nixos-22.11";
   };
 
-  outputs = { flake-parts, ... }@inputs:
+  outputs = { flake-parts, self, ... }@inputs:
     flake-parts.lib.mkFlake { inherit inputs; } (
       flake-parts.lib.mkFlake
         {
+          inherit inputs;
           # Workaround for https://github.com/hercules-ci/flake-parts/issues/148
-          inputs = inputs // { self.outPath = ./.; };
+          self = {
+            outPath = ./.;
+            inherit (self)
+              _type inputs lastModified lastModifiedDate narHash outputs sourceInfo submodules;
+          };
         }
         ./modules/dogfood.nix
     ).flakeModules.dogfood;

--- a/template/dogfood/modules/anotherFlakeModule.nix
+++ b/template/dogfood/modules/anotherFlakeModule.nix
@@ -1,0 +1,8 @@
+{inputs, ...}: {
+  imports = [
+    inputs.flake-parts.flakeModules.flakeModules
+  ];
+  flake.flakeModules.anotherFlakeModule = {
+    # Define another flake module here
+  };
+}

--- a/template/dogfood/modules/dogfood.nix
+++ b/template/dogfood/modules/dogfood.nix
@@ -1,32 +1,23 @@
-{flake-parts-lib, lib, inputs, ...}: {
+{flake-parts-lib, lib, inputs, ...}@topLevel: {
   imports = [
     ./hello.nix
     inputs.flake-parts.flakeModules.flakeModules
   ];
-  config.systems = [ "x86_64-linux" "aarch64-darwin" ];
-  options.flake = lib.mkOption {
-    type = lib.types.submoduleWith {
-      modules = [
-        (flake: {
-          flakeModules.dogfood = {
-            config.systems = [ "x86_64-linux" "aarch64-darwin" ];
-            imports = [
-              flake.config.flakeModules.hello
+  flake.flakeModules.dogfood = {
+    config.systems = [ "x86_64-linux" "aarch64-darwin" ];
+    imports = [
+      topLevel.config.flake.flakeModules.hello
 
-              # Expose flake modules
-              ./dogfood.nix
-              ./hello.nix
-              ./anotherFlakeModule.nix
-            ];
-            options.perSystem = flake-parts-lib.mkPerSystemOption (perSystem: {
-              apps.default = {
-                type = "app";
-                program = "${perSystem.config.packages.hello_22_11}/bin/hello";
-              };
-            });
-          };
-        })
-      ];
-    };
+      # Expose flake modules
+      ./dogfood.nix
+      ./hello.nix
+      ./anotherFlakeModule.nix
+    ];
+    options.perSystem = flake-parts-lib.mkPerSystemOption (perSystem: {
+      apps.default = {
+        type = "app";
+        program = "${perSystem.config.packages.hello_22_11}/bin/hello";
+      };
+    });
   };
 }

--- a/template/dogfood/modules/dogfood.nix
+++ b/template/dogfood/modules/dogfood.nix
@@ -1,0 +1,32 @@
+{flake-parts-lib, lib, inputs, ...}: {
+  imports = [
+    ./hello.nix
+    inputs.flake-parts.flakeModules.flakeModules
+  ];
+  config.systems = [ "x86_64-linux" "aarch64-darwin" ];
+  options.flake = lib.mkOption {
+    type = lib.types.submoduleWith {
+      modules = [
+        (flake: {
+          flakeModules.dogfood = {
+            config.systems = [ "x86_64-linux" "aarch64-darwin" ];
+            imports = [
+              flake.config.flakeModules.hello
+
+              # Expose flake modules
+              ./dogfood.nix
+              ./hello.nix
+              ./anotherFlakeModule.nix
+            ];
+            options.perSystem = flake-parts-lib.mkPerSystemOption (perSystem: {
+              apps.default = {
+                type = "app";
+                program = "${perSystem.config.packages.hello_22_11}/bin/hello";
+              };
+            });
+          };
+        })
+      ];
+    };
+  };
+}

--- a/template/dogfood/modules/hello.nix
+++ b/template/dogfood/modules/hello.nix
@@ -1,0 +1,11 @@
+{inputs, flake-parts-lib, ...}: {
+  imports = [
+    inputs.flake-parts.flakeModules.flakeModules
+  ];
+  flake.flakeModules.hello = {
+    options.perSystem = flake-parts-lib.mkPerSystemOption ({ system, ... }: {
+      packages.hello_22_11 =
+        inputs.nixpkgs_22_11.legacyPackages.${system}.hello;
+    });
+  };
+}


### PR DESCRIPTION
## Motivation
- #104
- #121
## Testing
```
nix flake show
```

```
git+file:///Users/twer/github/flake-parts?dir=template/dogfood
├───apps
│   ├───aarch64-darwin
│   │   └───default: app
│   └───x86_64-linux
│       └───default: app
├───flakeModule: unknown
├───flakeModules: unknown
└───packages
    ├───aarch64-darwin
    │   └───hello_22_11: package 'hello-2.12.1'
    └───x86_64-linux
        └───hello_22_11 omitted (use '--all-systems' to show)
```

```
nix repl
```

```
Welcome to Nix 2.15.0. Type :? for help.

nix-repl> :lf .
warning: Git tree '/Users/twer/github/flake-parts' is dirty
Added 20 variables.

nix-repl> flakeModules
{ anotherFlakeModule = { ... }; dogfood = { ... }; hello = { ... }; }

nix-repl> 
```