### PR TITLE
Add aarch64-linux and x86_64-darwin systems to the default template

### DIFF
--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -14,7 +14,7 @@
         # 3. Add here: foo.flakeModule
 
       ];
-      systems = [ "x86_64-linux" "aarch64-darwin" ];
+      systems = [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" "x86_64-darwin" ];
       perSystem = { config, self', inputs', pkgs, system, ... }: {
         # Per-system attributes can be defined here. The self' and inputs'
         # module parameters provide easy access to attributes of the same


### PR DESCRIPTION
The default template had only aarch64-darwin and  x86-64-linux systems. I've added aarch linux and x86-64 darwin