### PR TITLE
apps: use lib.getExe to find executable

### DIFF
--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -3,6 +3,7 @@ let
   inherit (lib)
     mkOption
     types
+    getExe
     ;
   inherit (flake-parts-lib)
     mkTransposedPerSystemModule
@@ -13,9 +14,6 @@ let
   derivationType = lib.types.package // {
     check = lib.isDerivation;
   };
-
-  getExe = x:
-    "${lib.getBin x}/bin/${x.meta.mainProgram or (throw ''Package ${x.name or ""} does not have meta.mainProgram set, so I don't know how to find the main executable. You can set meta.mainProgram, or pass the full path to executable, e.g. program = "''${pkg}/bin/foo"'')}";
 
   appType = lib.types.submodule {
     options = {


### PR DESCRIPTION
Use nixpkgs version of [getExe](https://github.com/NixOS/nixpkgs/blob/39ae486d8caecdf1a057ae334381e477b93ebde9/lib/meta.nix#L146) to determine the executable name.

This brings it inline with the behavior of [the rest of the ecosystem](https://github.com/NixOS/nix/blob/c0e735f474a3a581cb08e8aa54e0001c9809ee92/src/nix/run.md?plain=1#L49-L51), which allows a fallback to the pname/name.

I tested this with a local repo to confirm.