### PR TITLE
moduleLocation, but also automatic

### DIFF
--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -28,17 +28,17 @@ rec {
 
   emptyExposeArgs = mkFlake
     { inputs.self = { outPath = "the self outpath"; }; }
-    ({ config, moduleLocation, errorLocation, ... }: {
+    ({ config, moduleLocation, ... }: {
       flake = {
-        inherit moduleLocation errorLocation;
+        inherit moduleLocation;
       };
     });
 
   emptyExposeArgsNoSelf = mkFlake
     { inputs.self = throw "self won't be available in case of some errors"; }
-    ({ config, moduleLocation, errorLocation, ... }: {
+    ({ config, moduleLocation, ... }: {
       flake = {
-        inherit moduleLocation errorLocation;
+        inherit moduleLocation;
       };
     });
 
@@ -179,10 +179,6 @@ rec {
     assert packagesNonStrictInDevShells.packages.a.default == pkg "a" "hello";
 
     assert emptyExposeArgs.moduleLocation == "the self outpath/flake.nix";
-
-    assert emptyExposeArgs.errorLocation == __curPos.file;
-
-    assert emptyExposeArgsNoSelf.errorLocation == __curPos.file;
 
     ok;
 

--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -26,6 +26,22 @@ rec {
       systems = [ ];
     };
 
+  emptyExposeArgs = mkFlake
+    { inputs.self = { outPath = "the self outpath"; }; }
+    ({ config, moduleLocation, errorLocation, ... }: {
+      flake = {
+        inherit moduleLocation errorLocation;
+      };
+    });
+
+  emptyExposeArgsNoSelf = mkFlake
+    { inputs.self = throw "self won't be available in case of some errors"; }
+    ({ config, moduleLocation, errorLocation, ... }: {
+      flake = {
+        inherit moduleLocation errorLocation;
+      };
+    });
+
   example1 = mkFlake
     { inputs.self = { }; }
     {
@@ -161,6 +177,12 @@ rec {
     assert flakeModulesDisable.test123 == "option123";
 
     assert packagesNonStrictInDevShells.packages.a.default == pkg "a" "hello";
+
+    assert emptyExposeArgs.moduleLocation == "the self outpath/flake.nix";
+
+    assert emptyExposeArgs.errorLocation == __curPos.file;
+
+    assert emptyExposeArgsNoSelf.errorLocation == __curPos.file;
 
     ok;
 

--- a/extras/flakeModules.nix
+++ b/extras/flakeModules.nix
@@ -1,4 +1,4 @@
-{ config, self, lib, flake-parts-lib, ... }:
+{ config, self, lib, flake-parts-lib, moduleLocation, ... }:
 let
   inherit (lib)
     filterAttrs
@@ -15,8 +15,8 @@ let
     type = types.lazyAttrsOf types.deferredModule;
     default = { };
     apply = mapAttrs (k: v: {
-      _file = "${toString self.outPath}/flake.nix#flakeModules.${k}";
-      key = "${toString self.outPath}/flake.nix#flakeModules.${k}";
+      _file = "${toString moduleLocation}#flakeModules.${k}";
+      key = "${toString moduleLocation}#flakeModules.${k}";
       imports = [ v ];
     });
     description = ''

--- a/lib.nix
+++ b/lib.nix
@@ -121,14 +121,17 @@ let
 
     mkFlake = args: module:
       let
-        loc =
+        inputsPos = builtins.unsafeGetAttrPos "inputs" args;
+        moduleLocation =
           args.moduleLocation or (
-            if args?inputs.self.outPath
+            if inputsPos != null
+            then inputsPos.file
+            else if args?inputs.self.outPath
             then args.inputs.self.outPath + "/flake.nix"
             else "<mkFlake argument>"
           );
-        mod = lib.setDefaultModuleLocation loc module;
-        eval = flake-parts-lib.evalFlakeModule args mod;
+        mod = lib.setDefaultModuleLocation moduleLocation module;
+        eval = flake-parts-lib.evalFlakeModule (args // { inherit moduleLocation; }) mod;
       in
       eval.config.flake;
 

--- a/lib.nix
+++ b/lib.nix
@@ -98,6 +98,7 @@ let
 
           ${errorExample}
         '')
+      , moduleLocation ? "${self.outPath}/flake.nix"
       }:
       throwIf
         (!args?self && !args?inputs) ''
@@ -117,7 +118,7 @@ let
         (module:
         lib.evalModules {
           specialArgs = {
-            inherit self flake-parts-lib;
+            inherit self flake-parts-lib moduleLocation;
             inputs = args.inputs or /* legacy, warned above */ self.inputs;
           } // specialArgs;
           modules = [ ./all-modules.nix module ];
@@ -138,9 +139,11 @@ let
     mkFlake = args: module:
       let
         loc =
-          if args?inputs.self.outPath
-          then args.inputs.self.outPath + "/flake.nix"
-          else "<mkFlake argument>";
+          args.moduleLocation or (
+            if args?inputs.self.outPath
+            then args.inputs.self.outPath + "/flake.nix"
+            else "<mkFlake argument>"
+          );
         mod = lib.setDefaultModuleLocation loc module;
         eval = flake-parts-lib.evalFlakeModule args mod;
       in

--- a/modules/nixosModules.nix
+++ b/modules/nixosModules.nix
@@ -1,4 +1,4 @@
-{ config, self, lib, flake-parts-lib, ... }:
+{ config, self, lib, flake-parts-lib, moduleLocation, ... }:
 let
   inherit (lib)
     filterAttrs
@@ -17,7 +17,7 @@ in
       nixosModules = mkOption {
         type = types.lazyAttrsOf types.unspecified;
         default = { };
-        apply = mapAttrs (k: v: { _file = "${toString self.outPath}/flake.nix#nixosModules.${k}"; imports = [ v ]; });
+        apply = mapAttrs (k: v: { _file = "${toString moduleLocation}#nixosModules.${k}"; imports = [ v ]; });
         description = ''
           NixOS modules.
 


### PR DESCRIPTION
This improves on #158 by making the default module location automatic.

When `moduleLocation` is specified, it behaves as in #158.
If not, the default module location is determined from the `inputs` attribute position, with fallback.

I believe `moduleLocation` is sufficient for the use cases in the flake-parts modules that were changed.
I am currently not aware of a case where `errorLocation` would have to be exposed to the modules, so I'd like to keep the interface minimal until we find that.
