### PR TITLE
raise error when flake attribute doesn't exist

### DIFF
--- a/modules/transposition.nix
+++ b/modules/transposition.nix
@@ -67,7 +67,11 @@ in
     perInput =
       system: flake:
       mapAttrs
-        (attrName: attrConfig: flake.${attrName}.${system})
+        (attrName: attrConfig:
+          flake.${attrName}.${system} or (throw ''
+            Attemt to access non existent attribute ${attrName}.${system} of flake ${flake}.
+          '')
+        )
         config.transposition;
 
     perSystem = {


### PR DESCRIPTION
Currently when trying to access packages from input flakes for a system that isn't supported by that flake, the error is not very conclusive.
It costed me at least an hour to grasp this. Now putting in this error message to prevent others from falling into the same trap.
