### PR TITLE
templates: make flake-parts input explicit

### DIFF
--- a/dev/tests/template.nix
+++ b/dev/tests/template.nix
@@ -15,18 +15,17 @@ hci-effects.mkEffect {
     nix -v flake init -t ${../..}
 
     ann pointing to local sources...
-    sed -i flake.nix -e 's^nixpkgs.url = ".*";^nixpkgs.url = "${path}"; flake-parts.url = "${../..}";^'
-    # head flake.nix
-    grep -F ${path} flake.nix >/dev/null
+
+    override=(--override-input flake-parts ${../..})
 
     ann nix flake lock...
-    nix flake lock
+    nix flake lock "''${override[@]}"
 
     ann nix flake show...
-    nix -v flake show
+    nix -v flake show "''${override[@]}"
 
     ann nix build...
-    nix build .
+    nix build . "''${override[@]}"
 
     ann checking result...
     readlink ./result | grep hello

--- a/template/default/flake.nix
+++ b/template/default/flake.nix
@@ -2,6 +2,7 @@
   description = "Description for the project";
 
   inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 

--- a/template/multi-module/flake.nix
+++ b/template/multi-module/flake.nix
@@ -2,6 +2,7 @@
   description = "Description for the project";
 
   inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 

--- a/template/package/flake.nix
+++ b/template/package/flake.nix
@@ -2,6 +2,7 @@
   description = "Description for the project";
 
   inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 

--- a/template/unfree/flake.nix
+++ b/template/unfree/flake.nix
@@ -1,7 +1,10 @@
 {
   description = "Description for the project";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
 
   outputs = inputs@{ flake-parts, nixpkgs, ... }:
     flake-parts.lib.mkFlake { inherit inputs; } {


### PR DESCRIPTION
Making the input implicit and relying on the registry has never worked for me, and I don't like relying on it

```
nix flake show
warning: Git tree '/home/matthew/tmp/llm-chain' is dirty
error:
       … while updating the lock file of flake 'git+file:///home/matthew/tmp/llm-chain'

       … while updating the flake input 'flake-parts'

       error: cannot find flake 'flake:flake-parts' in the flake registries
```

Each new template would just do this for me, and I always end up having to write the input explicitly anyway.
