### PR TITLE
Add flake.modules (opt-in)

### DIFF
--- a/dev/flake-module.nix
+++ b/dev/flake-module.nix
@@ -1,4 +1,4 @@
-{ config, lib, inputs, withSystem, ... }:
+{ config, lib, inputs, self, withSystem, ... }:
 
 {
   imports = [
@@ -64,7 +64,7 @@
     };
 
     checks.eval-tests =
-      let tests = import ./tests/eval-tests.nix;
+      let tests = import ./tests/eval-tests.nix { flake-parts = self; };
       in tests.runTests pkgs.emptyFile // { internals = tests; };
 
   };

--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -1,18 +1,13 @@
 # Run with
 #
-#     nix build -f dev checks.x86_64-linux.eval-tests
+#     nix build .#checks.x86_64-linux.eval-tests
 
+{ flake-parts }:
 rec {
-  f-p = builtins.getFlake (toString ../..);
-  flake-parts = f-p;
-
-  devFlake = builtins.getFlake (toString ../.);
-  nixpkgs = devFlake.inputs.nixpkgs;
-
-  f-p-lib = f-p.lib;
-
+  nixpkgs = flake-parts.inputs.nixpkgs;
+  f-p-lib = flake-parts.lib;
   inherit (f-p-lib) mkFlake;
-  inherit (f-p.inputs.nixpkgs-lib) lib;
+  inherit (flake-parts.inputs.nixpkgs-lib) lib;
 
   pkg = system: name:
     derivation

--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -88,6 +88,24 @@ rec {
       };
     };
 
+  modulesFlake = mkFlake
+    {
+      inputs.self = { };
+      moduleLocation = "modulesFlake";
+    }
+    {
+      imports = [ flake-parts.flakeModules.modules ];
+      systems = [ ];
+      flake = {
+        modules.generic.example = { lib, ... }: {
+          options.generic.example = lib.mkOption { default = "works in any module system application"; };
+        };
+        modules.foo.example = { lib, ... }: {
+          options.foo.example = lib.mkOption { default = "works in foo application"; };
+        };
+      };
+    };
+
   flakeModulesDeclare = mkFlake
     { inputs.self = { outPath = ./.; }; }
     ({ config, ... }: {
@@ -212,6 +230,20 @@ rec {
     assert packagesNonStrictInDevShells.packages.a.default == pkg "a" "hello";
 
     assert emptyExposeArgs.moduleLocation == "the self outpath/flake.nix";
+
+    assert (lib.evalModules {
+      class = "barrr";
+      modules = [
+        modulesFlake.modules.generic.example
+      ];
+    }).config.generic.example == "works in any module system application";
+
+    assert (lib.evalModules {
+      class = "foo";
+      modules = [
+        modulesFlake.modules.foo.example
+      ];
+    }).config.foo.example == "works in foo application";
 
     assert specialArgFlake.foo;
 

--- a/extras/modules.nix
+++ b/extras/modules.nix
@@ -1,0 +1,69 @@
+{ lib, moduleLocation, ... }:
+let
+  inherit (lib)
+    mapAttrs
+    mkOption
+    types
+    ;
+  inherit (lib.strings)
+    escapeNixIdentifier
+    ;
+
+  addInfo = class: moduleName:
+    if class == "generic"
+    then module: module
+    else
+      module:
+      # TODO: set key?
+      {
+        _class = class;
+        _file = "${toString moduleLocation}#modules.${escapeNixIdentifier class}.${escapeNixIdentifier moduleName}";
+        imports = [ module ];
+      };
+in
+{
+  options = {
+    flake.modules = mkOption {
+      type = types.lazyAttrsOf (types.lazyAttrsOf types.deferredModule);
+      description = ''
+        Groups of modules published by the flake.
+
+        The outer attributes declare the [`class`](https://nixos.org/manual/nixpkgs/stable/#module-system-lib-evalModules-param-class) of the modules within it.
+        The special attribute `generic` does not declare a class, allowing its modules to be used in any module class.
+      '';
+      example = lib.literalExpression ''
+        {
+          # NixOS configurations are modules with class "nixos"
+          nixos = {
+            # You can define a module right here:
+            noBoot = { config, ... }: {
+              boot.loader.enable = false;
+            };
+            # Or you may refer to it by file
+            autoDeploy = ./nixos/auto-deploy.nix;
+            # Or maybe you need both
+            projectIcarus = { config, pkgs, ... }: {
+              imports = [ ./nixos/project-icarus.nix ];
+              services.project-icarus.package =
+                withSystem pkgs.stdenv.hostPlatform.system ({ config, ... }:
+                  config.packages.default
+                );
+            };
+          };
+          # Flake-parts modules
+          # If you're not just publishing a module, but also using it locally,
+          # create a let binding to declare it before calling `mkFlake` so you can
+          # use it in both places.
+          flake = {
+            foo = someModule;
+          };
+          # Modules that can be loaded anywhere
+          generic = {
+            my-pkgs = { _module.args.my-pkgs = …; };
+          };
+        }
+      '';
+      apply = mapAttrs (k: mapAttrs (addInfo k));
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -48,6 +48,7 @@
       flakeModules = {
         easyOverlay = ./extras/easyOverlay.nix;
         flakeModules = ./extras/flakeModules.nix;
+        modules = ./extras/modules.nix;
         partitions = ./extras/partitions.nix;
       };
     in


### PR DESCRIPTION
Allow modules of any class to be published.
This removes the need for custom flake attributes, such as `nixosModules`, `flakeModules`, etc.

- Depends on #154 (somewhat)