### PR TITLE
docs: recommend setting `moduleLocation` by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,10 @@ then slide `mkFlake` between your outputs function head and body,
 
 ```nix
   outputs = inputs@{ flake-parts, ... }:
-    flake-parts.lib.mkFlake { inherit inputs; } {
+    flake-parts.lib.mkFlake {
+      inherit inputs;
+      moduleLocation = ./flake.nix;
+    } {
       flake = {
         # Put your original flake attributes here.
       };


### PR DESCRIPTION
As `moduleLocation` can be used to avoid portential infinite loops issue, it would be nice to mention it from README.