### PR TITLE
apps: Add `meta` option

### DIFF
--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -165,12 +165,14 @@ rec {
           hello = {
             program = "${pkg "a" "hello"}/bin/hello";
             type = "app";
+            meta = { };
           };
         };
         b = {
           hello = {
             program = "${pkg "b" "hello"}/bin/hello";
             type = "app";
+            meta = { };
           };
         };
       };

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -34,6 +34,16 @@ let
           A path to an executable or a derivation with `meta.mainProgram`.
         '';
       };
+      meta = mkOption {
+        type = types.lazyAttrsOf lib.types.raw;
+        default = { };
+        description = ''
+          Metadata information about the app.
+          Standardaized in Nix at <https://github.com/NixOS/nix/pull/11297>.
+
+          Note: `nix flake check` is only aware of the `description` attribute in `meta`.
+        '';
+      };
     };
   };
 in

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -37,6 +37,7 @@ let
       meta = mkOption {
         type = types.lazyAttrsOf lib.types.raw;
         default = { };
+        # TODO refer to Nix manual 2.25
         description = ''
           Metadata information about the app.
           Standardized in Nix at <https://github.com/NixOS/nix/pull/11297>.

--- a/modules/apps.nix
+++ b/modules/apps.nix
@@ -39,7 +39,7 @@ let
         default = { };
         description = ''
           Metadata information about the app.
-          Standardaized in Nix at <https://github.com/NixOS/nix/pull/11297>.
+          Standardized in Nix at <https://github.com/NixOS/nix/pull/11297>.
 
           Note: `nix flake check` is only aware of the `description` attribute in `meta`.
         '';


### PR DESCRIPTION
This allows specifying metadata info about the flake app. This has been standardised in Nix at https://github.com/NixOS/nix/pull/11297

Here’s an example of its usage:
```nix
# Inside perSystem
{
  apps.hello = {
    program = pkgs.hello;
    type = "app";
    meta.description = "I say hello!";
  };
}
```
