### PR TITLE
Remove the default value of `extraInputsFlake`

### DIFF
--- a/dev/tests/eval-tests.nix
+++ b/dev/tests/eval-tests.nix
@@ -158,6 +158,17 @@ rec {
       flake.foo = true;
     });
 
+  partitionWithoutExtraInputsFlake = mkFlake
+    {
+      inputs.self = { };
+    }
+    ({ config, ... }: {
+      imports = [ flake-parts.flakeModules.partitions ];
+      systems = [ "x86_64-linux" ];
+      partitions.dev.module = { inputs, ... }: builtins.seq inputs { };
+      partitionedAttrs.devShells = "dev";
+    });
+
   runTests = ok:
 
     assert empty == {
@@ -241,6 +252,8 @@ rec {
     }).config.foo.example == "works in foo application";
 
     assert specialArgFlake.foo;
+
+    assert builtins.isAttrs partitionWithoutExtraInputsFlake.devShells.x86_64-linux;
 
     ok;
 

--- a/extras/partitions.nix
+++ b/extras/partitions.nix
@@ -12,7 +12,6 @@ let
     options = {
       extraInputsFlake = mkOption {
         type = types.raw;
-        default = { };
         description = ''
           Location of a flake whose inputs to add to the inputs module argument in the partition.
           Note that flake `follows` are resolved without any awareness of inputs that are not in the flake.


### PR DESCRIPTION
`options.extraInputsFlake.isDefined` is always `true` if there is a default value for `extraInputsFlake`, which might not be desired.