### PR TITLE
Use inputs from `github:nix-community/nixpkgs.lib` instead of the hard-coded SHA-1 hash of the subdirectory git tree

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,14 +2,17 @@
   "nodes": {
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1725233747,
+        "lastModified": 1726155622,
         "narHash": "sha256-Ss8QWLXdr2JCBPcYChJhz4xJm+h/xjl4G0c0XlP6a74=",
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "356624c12086a18f2ea2825fed34523d60ccc4e3",
+        "type": "github"
       },
       "original": {
-        "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Flake basics described using the module system";
 
   inputs = {
-    nixpkgs-lib.url = "https://github.com/NixOS/nixpkgs/archive/356624c12086a18f2ea2825fed34523d60ccc4e3.tar.gz"; # 12228ff1752d7b7624a54e9c1af4b222b3c1073b /lib from nixos-unstable
+    nixpkgs-lib.url = "github:nix-community/nixpkgs.lib";
   };
 
   outputs = inputs@{ nixpkgs-lib, ... }:


### PR DESCRIPTION
This PR enables `nix flake lock` to update nixpkgs lib.