### PR TITLE
Set `key` for `modules` and `nixosModules`

### DIFF
--- a/extras/modules.nix
+++ b/extras/modules.nix
@@ -14,10 +14,10 @@ let
     then module: module
     else
       module:
-      # TODO: set key?
       {
         _class = class;
         _file = "${toString moduleLocation}#modules.${escapeNixIdentifier class}.${escapeNixIdentifier moduleName}";
+        key = "${toString moduleLocation}#modules.${escapeNixIdentifier class}.${escapeNixIdentifier moduleName}";
         imports = [ module ];
       };
 in

--- a/modules/nixosModules.nix
+++ b/modules/nixosModules.nix
@@ -15,7 +15,11 @@ in
       nixosModules = mkOption {
         type = types.lazyAttrsOf types.deferredModule;
         default = { };
-        apply = mapAttrs (k: v: { _file = "${toString moduleLocation}#nixosModules.${k}"; imports = [ v ]; });
+        apply = mapAttrs (k: v: {
+          _file = "${toString moduleLocation}#nixosModules.${k}";
+          key = "${toString moduleLocation}#nixosModules.${k}";
+          imports = [ v ];
+        });
         description = ''
           NixOS modules.
 


### PR DESCRIPTION
Fixes https://github.com/NixOS/nixpkgs/issues/340361