### PR TITLE
Add custom merge error for unknown flake output attrs

### DIFF
--- a/modules/flake.nix
+++ b/modules/flake.nix
@@ -10,7 +10,23 @@ in
     flake = mkOption {
       type = types.submoduleWith {
         modules = [
-          { freeformType = types.lazyAttrsOf types.raw; }
+          {
+            freeformType =
+              types.lazyAttrsOf
+                (types.unique
+                  {
+                    message = ''
+                      No option has been declared for this flake output attribute, so its definitions can't be merged automatically.
+                      Possible solutions:
+                        - Load a module that defines this flake output attribute
+                          Many modules are listed at https://flake.parts
+                        - Declare an option for this flake output attribute
+                        - Make sure the output attribute is spelled correctly
+                        - Define the value only once, with a single definition in a single module
+                    '';
+                  }
+                  types.raw);
+          }
         ];
       };
       description = ''


### PR DESCRIPTION
- Help with #264

```
nix-repl>  lib.mkFlake { inputs = {}; } ({ lib, ... }: { flake.a = lib.mkMerge ["a" "b"]; })
{
  a = «error: The option `flake.a' is defined multiple times while it's expected to be unique.
No option has been declared for this flake output attribute, so its definitions can't be merged automatically.
Possible solutions:
  - Load a module that defines this flake output attribute
    Many modules are listed at https://flake.parts
  - Declare an option for this flake output attribute
  - Make sure the output attribute is spelled correctly
  - Define the value only once, with a single definition in a single module

Definition values:
- In `<mkFlake argument>': "a"
- In `<mkFlake argument>': "b"
Use `lib.mkForce value` or `lib.mkDefault value` to change the priority on any of these definitions.
»;
[...]
```