### PR TITLE
partitions: allow merging multiple partitions per attr

### DIFF
--- a/extras/partitions.nix
+++ b/extras/partitions.nix
@@ -95,7 +95,7 @@ in
 {
   options = {
     partitionedAttrs = mkOption {
-      type = types.attrsOf types.str;
+      type = types.attrsOf (types.coercedTo types.str lib.singleton (types.nonEmptyListOf types.str));
       default = { };
       description = ''
         A set of flake output attributes that are taken from a partition instead of the default top level flake-parts evaluation.
@@ -147,7 +147,12 @@ in
     _module.args.partitionStack = [ ];
     flake = optionalAttrs (partitionStack == [ ]) (
       mapAttrs
-        (attrName: partition: lib.mkForce (config.partitions.${partition}.module.flake.${attrName}))
+        (
+          attrName: partitions:
+            lib.mkMerge (
+              map (partition: lib.mkForce config.partitions.${partition}.module.flake.${attrName}) partitions
+            )
+        )
         config.partitionedAttrs
     );
   };


### PR DESCRIPTION
I was looking at refactoring nixvim's flake configuration to take advantage of partitions (https://github.com/nix-community/nixvim/pull/3029), however I noticed that `partitionedAttrs` currently only supports one partition per output attr.

As an example, it might be useful to have the `checks` output attr defined by both `dev` and `docs` partitions, along with maybe some checks defined in the root configuration.

Fixes #258