### PR TITLE
debug: enable by default inside Nix REPL

### DIFF
--- a/modules/debug.nix
+++ b/modules/debug.nix
@@ -22,7 +22,8 @@ in
   options = {
     debug = mkOption {
       type = types.bool;
-      default = false;
+      default = builtins ? currentSystem;
+      defaultText = "true when inside Nix REPL";
       description = ''
         Whether to add the attributes `debug`, `allSystems` and `currentSystem`
         to the flake output. When `true`, this allows inspection of options via


### PR DESCRIPTION
Figured out this trick because this module already does some conditional logic based on `builtins ? currentSystem`

https://github.com/hercules-ci/flake-parts/blob/c621e8422220273271f52058f618c94e405bb0f5/modules/debug.nix#L74-L76