### PR TITLE
lib: add `modulesPath` to `evalFlakeModule`

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -118,6 +118,7 @@ let
           specialArgs = {
             inherit self flake-parts-lib moduleLocation;
             inputs = args.inputs or /* legacy, warned above */ self.inputs;
+            modulesPath = toString ./modules;
           } // specialArgs;
           modules = [ ./all-modules.nix (lib.setDefaultModuleLocation errorLocation module) ];
           class = "flake";


### PR DESCRIPTION
With the addition of `modulesPath`, it will be possible to do the same [as in NixOS](https://nixos.wiki/wiki/NixOS_modules#modulesPath):
```nix
flake-parts.lib.mkFlake { inherit inputs; } ({modulesPath, ...}: {
  disabledModules = [
    (modulesPath + "/nixosModules.nix")
  ];
});
```