### PR TITLE
fix(inputs'): do not unnecessarily evaluate formatters

### DIFF
--- a/dev/tests/nix-unit.nix
+++ b/dev/tests/nix-unit.nix
@@ -567,6 +567,31 @@ in
     };
   };
 
+  perInput = {
+    "test: inputs' does not evaluate input flake formatter" =
+      let
+        inputFlake = {
+          _type = "flake";
+          outPath = "/fake";
+          formatter = throw "must not evaluate input's formatter";
+          packages.a.hello = pkg "a" "hello";
+        };
+        self = { _type = "flake"; outPath = "/test"; inputs = { inherit self; dep = inputFlake; }; };
+        result = mkFlake
+          { inputs = self.inputs; }
+          {
+            systems = [ "a" ];
+            perSystem = { inputs', ... }: {
+              packages.default = inputs'.dep.packages.hello;
+            };
+          };
+      in
+      {
+        expr = (result.packages.a.default).name;
+        expected = "hello";
+      };
+  };
+
   formatter = {
     "test: conditional null throws helpful error" = {
       expr =

--- a/modules/formatter.nix
+++ b/modules/formatter.nix
@@ -100,10 +100,9 @@ in
               '')
           config.allSystems);
 
-    perInput = system: flake:
-      optionalAttrs (flake?formatter.${system}) {
-        formatter = flake.formatter.${system};
-      };
+    perInput = system: flake: {
+      formatter = flake.formatter.${system};
+    };
 
   };
 }


### PR DESCRIPTION
This compromises the ability to `inputs'?formatter`, but that seems like a particularly rare use case.
Instead, we treat `inputs'` as another "programmatic" as opposed to "polished" interfaces, similar to the `config` vs flake attributes distinction.
The programmatic interfaces always prioritize laziness whereas the polished interfaces may choose to omit known-missing things, to a reasonable degree.

- Closes #348