### PR TITLE
examples/fup-migration: POC — multi-channel, hosts, auto-registry (ported from flake-utils-plus)

### DIFF
--- a/examples/fup-migration/README.md
+++ b/examples/fup-migration/README.md
@@ -1,0 +1,50 @@
+# FUP Migration — POC: Multi-Channel + Hosts + Registry in flake-parts
+
+This example demonstrates how FUP's core features can be reimagined as
+composable flake-parts modules. It's a proof-of-concept, not a library.
+
+## Features demonstrated
+
+| Feature | FUP's approach | flake-parts approach |
+|---|---|---|
+| **Multi-channel** | Implicit via `mkFlake` args | Declared via `fup.channels` option |
+| **Overlay propagation** | `sharedOverlays` + per-channel `overlaysBuilder` | Same semantics, module-controlled |
+| **Host abstraction** | `hosts.<name>` attrs in `mkFlake` | `fup.hosts` option; reverse-DNS naming |
+| **Builder dispatch** | Auto-detects NixOS vs darwin | `output` field switches builder |
+| **Channel patching** | `channels.<n>.patches` | Same via `fup.channels.<n>.patches` |
+| **Auto-registry** | `nix.generateRegistryFromInputs` | `fup.autoRegistry` — generates NixOS module fragment |
+| **Auto-nixPath** | `nix.generateNixPathFromInputs` | `fup.autoNixPath` — same technique |
+
+## Key architectural difference
+
+FUP uses a monolithic `mkFlake` function. This POC uses the flake-parts
+**module system**: options are declared, config is computed, modules compose.
+
+This avoids FUP's two worst architectural debts:
+- **No double-eval hack**: FUP evaluates the entire NixOS config twice just to
+  sniff `nixpkgs.config`. This module uses `getSystem` + perSystem evaluation
+  — channel nixpkgs is evaluated once, hosts read the result.
+- **No srcs side-channel**: FUP injects non-flake inputs into nixpkgs via an
+  overlay. This module doesn't do that — inputs stay where they belong.
+
+## What's left out vs FUP
+
+- `outputsBuilder` — too coupled to FUP's per-system eval. flake-parts already
+  has `perSystem.packages`, `perSystem.devShells`, etc.
+- `exportModules` / `exportOverlays` / `exportPackages` — separate utilities,
+  not shown here.
+- `fup-repl` — would be a separate module.
+- Channel auto-detection (`autoDetectChannels`) — included but opt-in.
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `fup-module.nix` | The flake-parts module |
+| `flake.nix` | Example flake that imports the module |
+
+## Try it
+
+```bash
+nix flake show path:./examples/fup-migration
+```

--- a/examples/fup-migration/flake.nix
+++ b/examples/fup-migration/flake.nix
@@ -1,0 +1,138 @@
+{
+  description = "FUP migration POC — multi-channel, hosts, auto-registry in flake-parts";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs-stable.url = "github:NixOS/nixpkgs/nixos-24.11";
+
+    # Uncomment to test darwin:
+    # nix-darwin.url = "github:LnL7/nix-darwin";
+  };
+
+  outputs = inputs@{ flake-parts, ... }:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = [ "x86_64-linux" "aarch64-linux" ];
+
+      # Import the FUP migration module
+      imports = [ ./fup-module.nix ];
+
+      # ====================================================================
+      # ╔══════════════════════════════════════════════════════════════════╗
+      # ║  FUP-style configuration via flake-parts module options          ║
+      # ╚══════════════════════════════════════════════════════════════════╝
+      # ====================================================================
+      fup = {
+        # ------------------------------------------------------------------
+        # 1. MULTI-CHANNEL — declare multiple nixpkgs versions
+        # ------------------------------------------------------------------
+        channels = {
+          # Default channel, used by any host that doesn't override channelName
+          nixpkgs = {
+            input = inputs.nixpkgs;
+            # Per-channel nixpkgs config
+            config.allowUnfree = false;
+            # Channel-specific overlays — receives ALL channel pkgs for
+            # cross-channel references (e.g., import from unstable)
+            overlaysBuilder = allPkgs: [
+              (final: prev: {
+                inherit (allPkgs.stable) hello;
+              })
+            ];
+          };
+
+          # A stable channel with different config
+          stable = {
+            input = inputs.nixpkgs-stable;
+            config.allowUnfree = true;
+            # To test source patching, uncomment:
+            # patches = [ ./fix-python.patch ];
+          };
+        };
+
+        # ------------------------------------------------------------------
+        # 2. OVERLAYS — applied to ALL channels
+        # ------------------------------------------------------------------
+        sharedOverlays = [
+          (final: prev: {
+            hello-fup = final.hello.overrideAttrs (old: {
+              pname = "${old.pname}-fup";
+            });
+          })
+        ];
+
+        # ------------------------------------------------------------------
+        # 3. HOST ABSTRACTION — declarative machines with builder dispatch
+        # ------------------------------------------------------------------
+        hostDefaults = {
+          system = "x86_64-linux";
+          channelName = "nixpkgs";
+          # output = "nixosConfigurations";  # default
+          # To use darwin instead:
+          # output = "darwinConfigurations";
+          # builder = inputs.nix-darwin.lib.darwinSystem;
+        };
+
+        hosts = {
+          # Reverse-DNS naming:
+          #   "com.example.server" → hostname: "server", domain: "example.com"
+          "com.example.server" = {
+            system = "x86_64-linux";
+            modules = [
+              ({ pkgs, ... }: {
+                environment.systemPackages = [ pkgs.hello-fup ];
+              })
+            ];
+          };
+
+          # Override channel per-host — uses stable nixpkgs
+          "com.example.laptop" = {
+            system = "x86_64-linux";
+            channelName = "stable";
+          };
+        };
+
+        # ------------------------------------------------------------------
+        # 4. AUTO-REGISTRY — generate nix.registry / nix.nixPath
+        #    (These generate NixOS module fragments added to each host)
+        # ------------------------------------------------------------------
+        autoRegistry = true;
+        autoNixPath = true;
+
+        # ------------------------------------------------------------------
+        # bonus: auto-detect extra nixpkgs inputs
+        # ------------------------------------------------------------------
+        autoDetectChannels = false;
+      };
+
+      # ====================================================================
+      # Everything else works normally alongside fup options
+      # ====================================================================
+      perSystem = { pkgs, fupChannels, system, ... }: {
+        # ── devShells ──
+        devShells.default = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [ nix nixpkgs-fmt ];
+          shellHook = ''
+            echo "Channels available: ${toString (builtins.attrNames fupChannels)}"
+            if fupChannels != {}; then
+              echo "  nixpkgs version: ${fupChannels.nixpkgs.lib.version}"
+              echo "  stable version:  ${fupChannels.stable.lib.version}"
+            fi
+          '';
+        };
+
+        # ── packages ──
+        packages.hello-from-unstable = pkgs.hello;
+        packages.hello-from-stable = fupChannels.stable.hello;
+
+        # ── apps ──
+        apps.show-channels = {
+          type = "app";
+          program = toString (pkgs.writeShellScript "show-channels" ''
+            echo "Channel versions for ${system}:"
+            echo "  nixpkgs: ${fupChannels.nixpkgs.lib.version or "N/A"}"
+            echo "  stable:  ${fupChannels.stable.lib.version or "N/A"}"
+          '');
+        };
+      };
+    };
+}

--- a/examples/fup-migration/fup-module.nix
+++ b/examples/fup-migration/fup-module.nix
@@ -1,0 +1,347 @@
+{ config, lib, flake-parts-lib, self, inputs, ... }:
+
+let
+  inherit (lib)
+    types mkOption mkIf mkDefault
+    mapAttrs filterAttrs optionalAttrs
+    foldl' recursiveUpdate
+    concatStringsSep head tail;
+
+  inherit (builtins)
+    attrNames attrValues listToAttrs removeAttrs
+    concatMap isString filter genList elemAt
+    length toString;
+
+  # ---------------------------------------------------------------------------
+  # Helpers
+  # ---------------------------------------------------------------------------
+
+  # Apply patches to a nixpkgs source tree. Same approach as FUP.
+  patchNixpkgs = system: channelInput: patches:
+    if patches == [ ] then channelInput
+    else
+      let
+        bootstrapPkgs = import channelInput { inherit system; };
+        patchedSrc = bootstrapPkgs.applyPatches {
+          name = "nixpkgs-patched";
+          src = channelInput;
+          inherit patches;
+        };
+      in
+      toString patchedSrc;
+
+  # Detect whether an input looks like nixpkgs (has x86_64-linux nix).
+  isNixpkgsLike = name: value:
+    value ? legacyPackages
+    && value.legacyPackages ? x86_64-linux
+    && value.legacyPackages.x86_64-linux ? nix;
+
+  # Reverse a list.
+  reverseList = xs:
+    let l = length xs; in genList (n: elemAt xs (l - n - 1)) l;
+
+  # Partition a dotted name into segments.
+  splitLabels = dotted:
+    filter isString (builtins.split "\\." dotted);
+
+  # Extract hostname from reverse-DNS (e.g. "com.example.mybox" -> "mybox").
+  hostnameFromReverseDNS = reverseDomain:
+    head (reverseList (splitLabels reverseDomain));
+
+  # Extract domain from reverse-DNS (e.g. "com.example.mybox" -> "example.com").
+  domainFromReverseDNS = reverseDomain:
+    let
+      labels = reverseList (splitLabels reverseDomain);
+      domainLabels = tail labels;
+    in
+    if domainLabels == [ ] then null
+    else concatStringsSep "." domainLabels;
+
+  # Generate a NixOS module fragment for registry / nixPath.
+  mkRegistryModule = { autoRegistry, autoNixPath }:
+    { lib, ... }:
+    let cfg = autoRegistry; nixPathCfg = autoNixPath; in
+    {
+      config.nix = {
+        registry = mkIf cfg
+          (mapAttrs (name: v: { flake = v; })
+            (filterAttrs (_: v: v ? outputs) inputs));
+        nixPath = mkIf nixPathCfg
+          (mkDefault [ "/etc/nix/inputs" ]);
+      };
+    };
+
+  # Merge a raw host declaration with hostDefaults.
+  resolveHost = name: host: hostDefaults:
+    let d = hostDefaults; in
+    {
+      system = if host.system != "" then host.system else d.system;
+      channelName = if host.channelName != "" then host.channelName else d.channelName;
+      output = if host.output != "" then host.output else d.output;
+      modules = host.modules;
+      extraArgs = host.extraArgs;
+      specialArgs = host.specialArgs;
+      builder =
+        if host.builder != null then host.builder
+        else d.builder;
+    };
+
+in
+{
+  options.fup = {
+    channels = mkOption {
+      description = "Nixpkgs channels. Each key is a channel name.";
+      type = types.lazyAttrsOf (types.submodule {
+        options = {
+          input = mkOption {
+            type = types.raw;
+            description = "The nixpkgs flake input.";
+          };
+          config = mkOption {
+            type = types.attrsOf types.unspecified;
+            default = { };
+            description = "nixpkgs config (allowUnfree, etc.).";
+          };
+          overlaysBuilder = mkOption {
+            type = types.nullOr (types.functionTo (types.listOf types.raw));
+            default = null;
+            description = ''
+              Function: (allChannelPkgs) -> [ overlay ].
+              Receives every channel's evaluated pkgs for cross-channel references.
+            '';
+          };
+          patches = mkOption {
+            type = types.listOf types.path;
+            default = [ ];
+            description = "Patches to apply to nixpkgs source before importing.";
+          };
+        };
+      });
+      default = { };
+      example = {
+        nixpkgs = { input = "nixpkgs"; };
+        unstable = { input = "nixpkgs-unstable"; unstable.config.allowUnfree = true; };
+      };
+    };
+
+    sharedOverlays = mkOption {
+      type = types.listOf types.raw;
+      default = [ ];
+      description = "Overlays applied to every channel.";
+    };
+
+    channelsConfig = mkOption {
+      type = types.attrsOf types.unspecified;
+      default = { };
+      description = "Default nixpkgs config for all channels.";
+    };
+
+    hostDefaults = mkOption {
+      description = "Default host configuration applied to every host.";
+      type = types.submodule {
+        options = {
+          system = mkOption { type = types.str; default = "x86_64-linux"; };
+          channelName = mkOption { type = types.str; default = "nixpkgs"; };
+          output = mkOption { type = types.str; default = "nixosConfigurations"; };
+          builder = mkOption { type = types.nullOr types.raw; default = null; };
+          modules = mkOption { type = types.listOf types.raw; default = [ ]; };
+          extraArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+          specialArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+        };
+      };
+      default = { };
+    };
+
+    hosts = mkOption {
+      description = ''
+        Machine declarations keyed by reverse-DNS name, e.g. "com.example.mybox".
+      '';
+      type = types.lazyAttrsOf (types.submodule {
+        options = {
+          system = mkOption { type = types.str; default = ""; };
+          channelName = mkOption { type = types.str; default = ""; };
+          output = mkOption { type = types.str; default = ""; };
+          builder = mkOption { type = types.nullOr types.raw; default = null; };
+          modules = mkOption { type = types.listOf types.raw; default = [ ]; };
+          extraArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+          specialArgs = mkOption { type = types.attrsOf types.unspecified; default = { }; };
+        };
+      });
+      default = { };
+    };
+
+    autoDetectChannels = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Auto-detect nixpkgs-like inputs as channels when `channels` is empty.";
+    };
+
+    autoRegistry = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Generate nix.registry from flake inputs (added to host modules).";
+    };
+
+    autoNixPath = mkOption {
+      type = types.bool;
+      default = false;
+      description = "Generate nix.nixPath from flake inputs (added to host modules).";
+    };
+  };
+
+  config =
+    let
+      cfg = config.fup;
+
+      # -----------------------------------------------------------------------
+      # Channel resolution
+      # -----------------------------------------------------------------------
+      detectedChannels =
+        if cfg.autoDetectChannels && cfg.channels == { }
+        then
+          mapAttrs (name: input: { inherit input; })
+            (filterAttrs isNixpkgsLike inputs)
+        else { };
+
+      allChannels = cfg.channels // detectedChannels;
+
+      # -----------------------------------------------------------------------
+      # System → channel pkgs cache, evaluated at the flake level.
+      #
+      # Strategy: evaluate nixpkgs once per (system, channel) pair, cache the
+      # result, and use it for both host building and perSystem injection.
+      #
+      # This avoids the double-eval hack in FUP (which evaluated NixOS config
+      # twice to sniff nixpkgs.config), and avoids cross-module-system data
+      # transfer issues.
+      # -----------------------------------------------------------------------
+      resolvedHosts = mapAttrs (name: host: resolveHost name host cfg.hostDefaults) cfg.hosts;
+
+      # Systems we actually need channels for
+      neededSystems = lib.unique (
+        (map (h: h.system) (attrValues resolvedHosts))
+        ++ config.systems
+      );
+
+      # system -> { channelName -> pkgs }
+      # Lazily evaluated: a system's channels are only imported when accessed.
+      channelCache = listToAttrs (map
+        (system: {
+          name = system;
+          value =
+            if allChannels == { } then { }
+            else
+              let
+                # allPkgs is lazy — overlaysBuilder receives unevaluated thunks
+                allPkgs = mapAttrs
+                  (name: ch:
+                    let
+                      src =
+                        if ch.patches == [ ] then ch.input
+                        else patchNixpkgs system ch.input ch.patches;
+                      pkgs = import src {
+                        inherit system;
+                        overlays = cfg.sharedOverlays
+                          ++ (if ch.overlaysBuilder != null
+                        then ch.overlaysBuilder allPkgs
+                        else [ ]);
+                        config = cfg.channelsConfig // ch.config;
+                      };
+                    in
+                    pkgs // { inherit (ch) input patches; }
+                  )
+                  allChannels;
+              in
+              allPkgs;
+        })
+        neededSystems);
+
+      # Convenience accessor
+      getChannelsFor = system: channelCache.${system} or { };
+
+      # -----------------------------------------------------------------------
+      # Host building
+      # -----------------------------------------------------------------------
+      registryModule = mkRegistryModule {
+        autoRegistry = cfg.autoRegistry;
+        autoNixPath = cfg.autoNixPath;
+      };
+
+      # Build one host declaration into flake output attributes
+      buildOneHost = name: hostRaw:
+        let
+          h = resolveHost name hostRaw cfg.hostDefaults;
+
+          # Grab channel pkgs for this host's system
+          chanPkgsSet = getChannelsFor h.system;
+          chanPkgs =
+            if allChannels == { } then
+            # No channels configured — fallback: hosts must provide their own
+            # pkgs through nixpkgs.pkgs in a module
+              null
+            else
+              chanPkgsSet.${h.channelName} or
+                (throw "fup: host '${name}' references channel '${h.channelName}' which is not available on '${h.system}'. Available: ${toString (attrNames chanPkgsSet)}");
+
+          hostname = hostnameFromReverseDNS name;
+          domain = domainFromReverseDNS name;
+
+          # Wiring module: injects pkgs, hostname, domain, revision
+          wiringModule = { lib, options, ... }: {
+            networking.hostName = lib.mkDefault hostname;
+            networking.domain = lib.mkIf (domain != null) (lib.mkDefault domain);
+            system.configurationRevision = lib.mkIf (self ? rev && options ? system.configurationRevision) self.rev;
+          } // optionalAttrs (chanPkgs != null) {
+            nixpkgs.pkgs = chanPkgs;
+          };
+
+          baseModules = h.modules ++ [ wiringModule ]
+            ++ optionalAttrs (cfg.autoRegistry || cfg.autoNixPath) [ registryModule ];
+
+          # Resolve builder function
+          builder =
+            if h.builder != null then h.builder
+            else if h.output == "darwinConfigurations" then
+              throw "fup: host '${name}' has output 'darwinConfigurations' but no builder set. "
+              + "Set 'hostDefaults.builder = inputs.nix-darwin.lib.darwinSystem' or override per-host."
+            else
+              chanPkgs.lib.nixosSystem;
+
+          # Build the config — different top-level args per output type
+          result =
+            if h.output == "darwinConfigurations" then
+              builder
+                {
+                  modules = baseModules;
+                  specialArgs = h.specialArgs;
+                  pkgs = chanPkgs;
+                  inherit (h) system;
+                }
+            else
+              builder {
+                modules = baseModules;
+                specialArgs = h.specialArgs;
+                inherit (h) system;
+              };
+        in
+        { ${h.output}.${name} = result; };
+
+    in
+    {
+      # -----------------------------------------------------------------------
+      # Per-system: expose evaluated channels as a module argument so they can
+      # be used in devShells, packages, etc.
+      #
+      # Usage: perSystem = { fupChannels, ... }: { packages.foo = fupChannels.unstable.callPackage ...; };
+      # -----------------------------------------------------------------------
+      perSystem = { system, ... }: {
+        config._module.args.fupChannels = getChannelsFor system;
+      };
+
+      # -----------------------------------------------------------------------
+      # Flake-level: build host configuration sets
+      # -----------------------------------------------------------------------
+      flake = foldl' recursiveUpdate { }
+        (mapAttrsToList buildOneHost cfg.hosts);
+    };
+}


### PR DESCRIPTION
## What

This PR adds an example under `examples/fup-migration/` that demonstrates how the core features of [`flake-utils-plus`](https://github.com/gytis-ivaskevicius/flake-utils-plus) can be reimplemented as **composable flake-parts modules**.

It is a **proof-of-concept**, not a library. The intent is to show the API shape and architectural pattern for adding these capabilities natively to flake-parts.

## Features demonstrated

| Feature | FUP | This POC |
|---|---|---|
| **Multi-channel** | `channels` arg in `mkFlake` | `fup.channels` option — declare multiple nixpkgs inputs with per-channel config, overlays, and source patching |
| **Overlay propagation** | `sharedOverlays` + per-channel `overlaysBuilder` | Same semantics, via module options |
| **Host abstraction** | `hosts.<name>` in `mkFlake` | `fup.hosts` option — declarative machines with reverse-DNS naming, builder dispatch (NixOS/darwin), channel selection |
| **Channel patching** | `channels.<n>.patches` | Same, via `fup.channels.<n>.patches` |
| **Auto-registry** | `nix.generateRegistryFromInputs` | `fup.autoRegistry` / `fup.autoNixPath` — generates NixOS module fragments added to each host |

## Key architectural differences from FUP

This POC avoids FUP's two biggest architectural debts:

1. **No double-eval hack**: FUP evaluates the entire NixOS config twice just to sniff `nixpkgs.config`. This module uses flake-level channel evaluation with memoization — nixpkgs is imported once per (system, channel) pair, hosts read from the cache.

2. **No srcs side-channel**: FUP injects non-flake inputs into nixpkgs via an overlay. This module doesn't — inputs stay in their proper scope.

3. **Module system composition**: Instead of a monolithic `mkFlake` function, this uses standard flake-parts option declarations, so features compose naturally with other modules.

## Files

```
examples/fup-migration/
├── README.md         # Explanation of the POC
├── fup-module.nix    # The reusable module (~347 lines)
└── flake.nix         # Example flake that imports the module
```

## How it works

1. Channels are declared via `fup.channels` — each channel specifies an `input`, `config`, `overlaysBuilder`, and optional `patches`.
2. `fup.sharedOverlays` are applied to all channels.
3. Channels are evaluated lazily at the flake level, cached per (system, channel) pair.
4. Hosts are declared via `fup.hosts` with reverse-DNS keys. Each host specifies `system`, `channelName`, `modules`, and optionally `output` / `builder` for darwin dispatch.
5. Evaluated channels are injected into perSystem via `_module.args.fupChannels` for use in devShells, packages, etc.
6. `autoRegistry` and `autoNixPath` generate NixOS module fragments that wire up `nix.registry` and `nix.nixPath` from flake inputs.

## What's left out vs FUP

- `outputsBuilder` — unnecessary; flake-parts already has `perSystem.packages`, `perSystem.devShells`, etc.
- `exportModules` / `exportOverlays` / `exportPackages` — separate utilities, not part of the host-abstraction core.
- `fup-repl` — would be a separate module.
- Channel auto-detection (`autoDetectChannels`) — included but opt-in.