### PR TITLE
perSystem: use inputs in perSystem instead of self.inputs

### DIFF
--- a/modules/perSystem.nix
+++ b/modules/perSystem.nix
@@ -1,4 +1,4 @@
-{ config, lib, flake-parts-lib, self, ... }:
+{ config, lib, flake-parts-lib, inputs, self, ... }:
 let
   inherit (lib)
     genAttrs
@@ -113,7 +113,7 @@ in
                     throw "Trying to retrieve system-dependent attributes for input ${escapeNixIdentifier inputName}, but this input is not a flake. Perhaps flake = false was added to the input declarations by mistake, or you meant to use a different input, or you meant to use plain old inputs, not inputs'."
                 )
               )
-              self.inputs;
+              inputs;
           _module.args.self' =
             builtins.addErrorContext "while retrieving system-dependent attributes for a flake's own outputs" (
               rootConfig.perInput system self


### PR DESCRIPTION
Change behavior of perSystem modules to not assume that self contains inputs.

This was made to allow use of alternative input methods, other than flake inputs, while still utilizing flakes.

In my example it's tack https://github.com/manic-systems/tack

But for the future flake agnostic flake parts (https://github.com/hercules-ci/flake-parts/issues/329) it could be one of the stepping stones for any pinning solution

I did not check if any modules depend on this behavior, but my config rebuid fine

commit switching to tack while successfully rebuilding the config 
https://github.com/Ladas552/Flake-Ocean/commit/6596e800e4d564f3ff252cf4d20f5a6a75856082