### PR TITLE
feat(flakeModules): forward to modules.flake, doc(changelog)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,16 @@
+# 2026-08-24
+
+ - For those who **publish** modules using the [`flakeModules` module]:
+   It now imports the [`modules` module] so as to make
+   output attribute `<your-flake>.modules.flake` available to module consumers.
+
+# 2026-05-04
+
+ - Add [`touchup`] module
+   for ad hoc flake output attribute modifications.
+
+ - Fix a strictness issue with [`formatter`] causing [`perSystem`] to be evaluated
+   for all [`systems`], unnecessarily.
 
 # 2026-01-05
 
@@ -114,3 +127,10 @@
  - `flake-modules-core` is now called `flake-parts`.
 
  - `flake.overlay` has been removed in favor of `flake.overlays.default`.
+
+[`formatter`]: https://flake.parts/options/flake-parts.html#opt-perSystem.formatter
+[`systems`]: https://flake.parts/options/flake-parts.html#opt-systems
+[`perSystem`]: https://flake.parts/options/flake-parts.html#opt-perSystem
+[`touchup`]: https://flake.parts/options/flake-parts-touchup.html
+[`flakeModules` module]: https://flake.parts/options/flake-parts-flakemodules
+[`modules` module]: https://flake.parts/options/flake-parts-modules.html

--- a/extras/flakeModules.nix
+++ b/extras/flakeModules.nix
@@ -32,14 +32,16 @@ let
   };
 in
 {
+  imports = [ ./modules.nix ];
   options = {
     flake = mkOption {
       type = types.submoduleWith {
         modules = [
           (mkAliasOptionModule [ "flakeModule" ] [ "flakeModules" "default" ])
-          {
+          ({ config, ... }: {
             options.flakeModules = flakeModulesOption;
-          }
+            config.modules.flake = config.flakeModules;
+          })
         ];
       };
     };


### PR DESCRIPTION
I'm considering a deprecation in favor of the more general `modules` option, but not before `modules` is available almost everywhere.