### PR TITLE
default moduleLocation: avoid copy to store.

### DIFF
--- a/lib.nix
+++ b/lib.nix
@@ -103,7 +103,7 @@ let
 
           ${errorExample}
         '')
-      , moduleLocation ? "${self.outPath}/flake.nix"
+      , moduleLocation ? self.outPath + "/flake.nix"
       }:
       let
         inputsPos = builtins.unsafeGetAttrPos "inputs" args;


### PR DESCRIPTION
use string concatenation instead of interpolation
to avoid copying outPath to the nix store
(when not using flake, otherwise its already there of course).